### PR TITLE
Ability to optionally watch content and re-init scroll bar on change.

### DIFF
--- a/src/js/ngSlimscroll.js
+++ b/src/js/ngSlimscroll.js
@@ -42,6 +42,8 @@ angular.module('jkuri.slimscroll', [])
 		scope.horizontalScroll = scope.$eval(attrs.horizontalScroll) || false;
 		scope.horizontalScrollPosition = attrs.horizontalScrollPosition || 'bottom';
 		scope.touchScrollStep = attrs.touchScrollStep || 200;
+		scope.watchContent = scope.$eval(attrs.watchContent) || false;
+
 	};
 
 	return {
@@ -284,19 +286,29 @@ angular.module('jkuri.slimscroll', [])
 					element.append(bar);
 					scope.attachWheel(el);
 				}
-
 			});
 
-			if (!scope.horizontalScroll) {
-				scope.getBarHeight();
-				scope.makeBarDraggable();
-			} else {
-				scope.getBarWidth();
-				scope.makeBarDraggableHorizontal();
+			if (scope.watchContent) {
+				var contentWatcher = scope.$watch(
+					function() { return element.html(); },
+					function() { scope.init(); }
+				)
+				scope.$on("$destroy", function () { contentWatcher(); });
 			}
 
-			scope.attachWheel(el);
-
+			scope.init = function () {
+				bar.css('top','0');
+				if (!scope.horizontalScroll) {
+					scope.getBarHeight();
+					scope.makeBarDraggable();
+				} else {
+					scope.getBarWidth();
+					scope.makeBarDraggableHorizontal();
+				}
+				scope.attachWheel(el);
+				return true;
+			}
+			scope.init();
 		}
 	};
 


### PR DESCRIPTION
Hello,  I wanted to use your directive in combination with ng-bind-html or {{variables}} and it was not working because the directive initialized before the content was rendered/loaded.  I have made a very small modification that will optionally watch the content of the scrollable div for changes and re-initialize on change.

```
<div ng-slimscroll height="150" watch-content="true">
  {{changableContent}}
</div>
```
